### PR TITLE
Add Signadot sidecar injection annotations to all deployments

### DIFF
--- a/api/chart/templates/api-deployment.yaml
+++ b/api/chart/templates/api-deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       terminationGracePeriodSeconds: 0
       {{- if .Values.load }}

--- a/catalog/chart/templates/deployment.yaml
+++ b/catalog/chart/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: catalog
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       terminationGracePeriodSeconds: 0
       initContainers:

--- a/frontend/chart/templates/deployment.yaml
+++ b/frontend/chart/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: frontend
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       terminationGracePeriodSeconds: 0
       containers:

--- a/kafka/values.yml
+++ b/kafka/values.yml
@@ -1,5 +1,7 @@
 controller:
   replicaCount: 1
+  podAnnotations:
+    sidecar.signadot.com/inject: "true"
 
 listeners:
   client:
@@ -11,6 +13,8 @@ persistence:
 zookeeper:
   persistence:
     size: 1Gi
+  podAnnotations:
+    sidecar.signadot.com/inject: "true"
 
 extraConfig: |
   offsets.topic.replication.factor=1

--- a/mongodb/values.yml
+++ b/mongodb/values.yml
@@ -2,6 +2,9 @@ image:
   repository: zcube/bitnami-compat-mongodb
   tag: 6.0.5
 
+podAnnotations:
+  sidecar.signadot.com/inject: "true"
+
 persistence:
   size: 1Gi
 

--- a/postgresql/values.yml
+++ b/postgresql/values.yml
@@ -6,3 +6,5 @@ auth:
 primary:
   persistence:
     size: 2Gi
+  podAnnotations:
+    sidecar.signadot.com/inject: "true"

--- a/rent/chart/templates/deployment.yaml
+++ b/rent/chart/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: rent
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       containers:
       - image: {{ .Values.image }}

--- a/worker/chart/templates/worker-deployment.yaml
+++ b/worker/chart/templates/worker-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: worker
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       containers:
         - image: {{ .Values.image }}


### PR DESCRIPTION
This PR adds the annotation 'sidecar.signadot.com/inject: "true"' to all deployments in the application.

## Changes made:

1. Added the annotation to pod templates in all Helm chart deployment templates:
   - frontend/chart/templates/deployment.yaml
   - catalog/chart/templates/deployment.yaml
   - rent/chart/templates/deployment.yaml
   - worker/chart/templates/worker-deployment.yaml
   - api/chart/templates/api-deployment.yaml

2. Added the annotation to pod templates in values files for third-party Helm charts:
   - postgresql/values.yml (added to primary.podAnnotations)
   - kafka/values.yml (added to controller.podAnnotations and zookeeper.podAnnotations)
   - mongodb/values.yml (added to podAnnotations)

These changes ensure that all deployments in the application will have the Signadot sidecar injected, which is required for proper functionality with Signadot.