### PR TITLE
Remove Signadot sidecar injection annotations from PostgreSQL and Kafka

### DIFF
--- a/kafka/values.yml
+++ b/kafka/values.yml
@@ -1,7 +1,5 @@
 controller:
   replicaCount: 1
-  podAnnotations:
-    sidecar.signadot.com/inject: "true"
 
 listeners:
   client:
@@ -13,8 +11,6 @@ persistence:
 zookeeper:
   persistence:
     size: 1Gi
-  podAnnotations:
-    sidecar.signadot.com/inject: "true"
 
 extraConfig: |
   offsets.topic.replication.factor=1

--- a/postgresql/values.yml
+++ b/postgresql/values.yml
@@ -6,5 +6,3 @@ auth:
 primary:
   persistence:
     size: 2Gi
-  podAnnotations:
-    sidecar.signadot.com/inject: "true"


### PR DESCRIPTION
This PR removes the Signadot sidecar injection annotations (`sidecar.signadot.com/inject: "true"`) from the PostgreSQL and Kafka services, while keeping them for all other services.

## Changes made:

1. Removed the annotation from PostgreSQL values file:
   - Removed `primary.podAnnotations.sidecar.signadot.com/inject` from `postgresql/values.yml`

2. Removed the annotation from Kafka values file:
   - Removed `controller.podAnnotations.sidecar.signadot.com/inject` from `kafka/values.yml`
   - Removed `zookeeper.podAnnotations.sidecar.signadot.com/inject` from `kafka/values.yml`

These changes ensure that the Signadot sidecar will not be injected into the PostgreSQL and Kafka pods, while still being injected into all other services.